### PR TITLE
chore: update Node to v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^22.0.0",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@types/styled-components": "^5.1.25",
@@ -28,5 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.yarnpkg.com"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Summary
- add Node >=22 engine requirement
- bump @types/node to ^22.0.0

## Testing
- `yarn install` (fails: RequestError 403)
- `yarn build` (fails: Configuration must contain `projectId`)


------
https://chatgpt.com/codex/tasks/task_e_68af60eaf23c832a8bc0ad7efe054188